### PR TITLE
Fixes for Async Teleporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <groupId>com.songoda</groupId>
     <artifactId>UltimateClaims</artifactId>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <build>
         <defaultGoal>clean install</defaultGoal>
         <finalName>UltimateClaims-${project.version}</finalName>

--- a/src/main/java/com/songoda/ultimateclaims/member/ClaimMember.java
+++ b/src/main/java/com/songoda/ultimateclaims/member/ClaimMember.java
@@ -91,7 +91,7 @@ public class ClaimMember {
         if (!isPresent || !(player = getPlayer()).isOnline()) return;
         Location spawn = UltimateClaims.getInstance().getPluginSettings().getSpawnPoint();
         if (spawn == null && location == null) return;
-        player.getPlayer().teleport(location == null ? spawn : location);
+        Bukkit.getScheduler().runTask(UltimateClaims.getInstance(), () -> player.getPlayer().teleport(location == null ? spawn : location));
         this.isPresent = false;
     }
 }


### PR DESCRIPTION
Some Spigot forks, maybe Spigot itself, doesn't allow player teleports to be done asynchronously. This is simply a workaround to fix the issue. Fixes SD-7574.